### PR TITLE
Add minimim cs high time between spi packets

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -368,6 +368,7 @@ class TMC2130Stepper : public TMCStepper {
 		struct DRV_STATUS_t { constexpr static uint8_t address = 0X6F; };
 
 		static uint32_t spi_speed; // Default 2MHz
+		static uint32_t cs_low_time;
 		const uint16_t _pinCS;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -3,6 +3,8 @@
 
 int8_t TMC2130Stepper::chain_length = 0;
 uint32_t TMC2130Stepper::spi_speed = 16000000/8;
+uint32_t TMC2130Stepper::cs_low_time = 2E9f/float(spi_speed)+50.;
+
 
 TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link) :
   TMCStepper(RS),
@@ -57,6 +59,7 @@ void TMC2130Stepper::defaults() {
 __attribute__((weak))
 void TMC2130Stepper::setSPISpeed(uint32_t speed) {
   spi_speed = speed;
+  cs_low_time = 2E9f/float(spi_speed)+50.;
 }
 
 __attribute__((weak))
@@ -114,6 +117,7 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
   }
 
   switchCSpin(HIGH);
+  delayNanoseconds(cs_low_time);
   switchCSpin(LOW);
 
   // Shift data from target link into the last one...
@@ -134,6 +138,7 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
 
   endTransaction();
   switchCSpin(HIGH);
+  delayNanoseconds(cs_low_time);
   return out;
 }
 


### PR DESCRIPTION
Datasheet for TMC5160 specifies that theres a minimum low time between packets being sent that wasn't implemented before. It was reliant on MCU clockspeed. I've added a delay based on the minimum time equations specified in the datasheet with some padding to be more conservative.